### PR TITLE
Separately fetch companies, departments and locations

### DIFF
--- a/pureservice-dotnet/Models/CompanyDepartmentList.cs
+++ b/pureservice-dotnet/Models/CompanyDepartmentList.cs
@@ -1,0 +1,5 @@
+using System.Collections.Generic;
+
+namespace pureservice_dotnet.Models;
+
+public record CompanyDepartmentList(List<CompanyDepartment> Companydepartments);

--- a/pureservice-dotnet/Models/CompanyList.cs
+++ b/pureservice-dotnet/Models/CompanyList.cs
@@ -1,0 +1,5 @@
+using System.Collections.Generic;
+
+namespace pureservice_dotnet.Models;
+
+public record CompanyList(List<Company> Companies);

--- a/pureservice-dotnet/Models/CompanyLocationList.cs
+++ b/pureservice-dotnet/Models/CompanyLocationList.cs
@@ -1,0 +1,5 @@
+using System.Collections.Generic;
+
+namespace pureservice_dotnet.Models;
+
+public record CompanyLocationList(List<CompanyLocation> Companylocations);

--- a/pureservice-dotnet/Services/PureserviceCompanyService.cs
+++ b/pureservice-dotnet/Services/PureserviceCompanyService.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Web;
 using Microsoft.Extensions.Logging;
 using pureservice_dotnet.Models;
 using Vestfold.Extensions.Metrics.Services;
@@ -10,6 +12,9 @@ public interface IPureserviceCompanyService
     Task<Company?> AddCompany(string companyName);
     Task<CompanyDepartment?> AddDepartment(string departmentName, int companyId);
     Task<CompanyLocation?> AddLocation(string locationName, int companyId);
+    Task<List<Company>> GetCompanies(int start = 0, int limit = 500);
+    Task<List<CompanyDepartment>> GetDepartments(int start = 0, int limit = 500);
+    Task<List<CompanyLocation>> GetLocations(int start = 0, int limit = 500);
 }
 
 public class PureserviceCompanyService : IPureserviceCompanyService
@@ -134,5 +139,128 @@ public class PureserviceCompanyService : IPureserviceCompanyService
         _metricsService.Count($"{Constants.MetricsPrefix}_LocationCreated", "Number of locations created",
             (Constants.MetricsResultLabelName, Constants.MetricsResultFailedLabelValue));
         return null;
+    }
+    
+    public async Task<List<Company>> GetCompanies(int start = 0, int limit = 500)
+    {
+        var companyList = new List<Company>();
+
+        var currentStart = start;
+        
+        var queryString = HttpUtility.ParseQueryString(string.Empty);
+
+        queryString["start"] = currentStart.ToString();
+        queryString["limit"] = limit.ToString();
+
+        CompanyList? result = null;
+        
+        while (result is null || result.Companies.Count > 0)
+        {
+            queryString["start"] = currentStart.ToString();
+            
+            result = await _pureserviceCaller.GetAsync<CompanyList>($"{CompanyBasePath}?{queryString}");
+            if (result is null)
+            {
+                _logger.LogError("No result returned from API from start {Start} with limit {Limit}", currentStart, limit);
+                return companyList;
+            }
+            
+            _logger.LogDebug("Fetched {Count} Pureservice companies starting from {Start} with limit {Limit}", result.Companies.Count, currentStart, limit);
+            companyList.AddRange(result.Companies);
+            
+            if (result.Companies.Count == 0)
+            {
+                _logger.LogInformation("Returning {CompanyCount} Pureservice companies", companyList.Count);
+                return companyList;
+            }
+
+            currentStart += result.Companies.Count;
+            _logger.LogDebug("Preparing to fetch next batch of Pureservice companies starting from start {Start} and limit {Limit}", currentStart, limit);
+        }
+        
+        _logger.LogWarning("Reached outside of while somehow 😱 Returning {CompanyCount} Pureservice companies", companyList.Count);
+        return companyList;
+    }
+    
+    public async Task<List<CompanyDepartment>> GetDepartments(int start = 0, int limit = 500)
+    {
+        var departmentList = new List<CompanyDepartment>();
+
+        var currentStart = start;
+        
+        var queryString = HttpUtility.ParseQueryString(string.Empty);
+
+        queryString["start"] = currentStart.ToString();
+        queryString["limit"] = limit.ToString();
+
+        CompanyDepartmentList? result = null;
+        
+        while (result is null || result.Companydepartments.Count > 0)
+        {
+            queryString["start"] = currentStart.ToString();
+            
+            result = await _pureserviceCaller.GetAsync<CompanyDepartmentList>($"{DepartmentBasePath}?{queryString}");
+            if (result is null)
+            {
+                _logger.LogError("No result returned from API from start {Start} with limit {Limit}", currentStart, limit);
+                return departmentList;
+            }
+            
+            _logger.LogDebug("Fetched {Count} Pureservice departments starting from {Start} with limit {Limit}", result.Companydepartments.Count, currentStart, limit);
+            departmentList.AddRange(result.Companydepartments);
+            
+            if (result.Companydepartments.Count == 0)
+            {
+                _logger.LogInformation("Returning {DepartmentCount} Pureservice departments", departmentList.Count);
+                return departmentList;
+            }
+
+            currentStart += result.Companydepartments.Count;
+            _logger.LogDebug("Preparing to fetch next batch of Pureservice departments starting from start {Start} and limit {Limit}", currentStart, limit);
+        }
+        
+        _logger.LogWarning("Reached outside of while somehow 😱 Returning {DepartmentCount} Pureservice departments", departmentList.Count);
+        return departmentList;
+    }
+    
+    public async Task<List<CompanyLocation>> GetLocations(int start = 0, int limit = 500)
+    {
+        var locationList = new List<CompanyLocation>();
+
+        var currentStart = start;
+        
+        var queryString = HttpUtility.ParseQueryString(string.Empty);
+
+        queryString["start"] = currentStart.ToString();
+        queryString["limit"] = limit.ToString();
+
+        CompanyLocationList? result = null;
+        
+        while (result is null || result.Companylocations.Count > 0)
+        {
+            queryString["start"] = currentStart.ToString();
+            
+            result = await _pureserviceCaller.GetAsync<CompanyLocationList>($"{LocationBasePath}?{queryString}");
+            if (result is null)
+            {
+                _logger.LogError("No result returned from API from start {Start} with limit {Limit}", currentStart, limit);
+                return locationList;
+            }
+            
+            _logger.LogDebug("Fetched {Count} Pureservice locations starting from {Start} with limit {Limit}", result.Companylocations.Count, currentStart, limit);
+            locationList.AddRange(result.Companylocations);
+            
+            if (result.Companylocations.Count == 0)
+            {
+                _logger.LogInformation("Returning {LocationCount} Pureservice locations", locationList.Count);
+                return locationList;
+            }
+
+            currentStart += result.Companylocations.Count;
+            _logger.LogDebug("Preparing to fetch next batch of Pureservice locations starting from start {Start} and limit {Limit}", currentStart, limit);
+        }
+        
+        _logger.LogWarning("Reached outside of while somehow 😱 Returning {LocationCount} Pureservice locations", locationList.Count);
+        return locationList;
     }
 }


### PR DESCRIPTION
Separately fetch **companies**, **departments** and **locations** to actually get all of them.
This to prevent falsely trying to create a **Company**, **CompanyDepartment** and/or **CompanyLocation** that already exists. (Closes #17)