### PR TITLE
Halt execution if crucial GET calls fails

### DIFF
--- a/pureservice-dotnet/Functions/UserFunctions.cs
+++ b/pureservice-dotnet/Functions/UserFunctions.cs
@@ -59,7 +59,7 @@ public class UserFunctions
         if (pureserviceUsers.Linked?.EmailAddresses is null || pureserviceUsers.Linked?.PhoneNumbers is null)
         {
             _logger.LogError("Expected linked results were not found in user list");
-            return;
+            throw new InvalidOperationException("Expected linked results were not found in user list");
         }
 
         var companies = await _pureserviceCompanyService.GetCompanies();

--- a/pureservice-dotnet/Services/PureserviceCompanyService.cs
+++ b/pureservice-dotnet/Services/PureserviceCompanyService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Web;
@@ -161,8 +162,7 @@ public class PureserviceCompanyService : IPureserviceCompanyService
             result = await _pureserviceCaller.GetAsync<CompanyList>($"{CompanyBasePath}?{queryString}");
             if (result is null)
             {
-                _logger.LogError("No result returned from API from start {Start} with limit {Limit}", currentStart, limit);
-                return companyList;
+                throw new InvalidOperationException($"No result returned from Pureservice API from start {currentStart} with limit {limit}");
             }
             
             _logger.LogDebug("Fetched {Count} Pureservice companies starting from {Start} with limit {Limit}", result.Companies.Count, currentStart, limit);
@@ -202,8 +202,7 @@ public class PureserviceCompanyService : IPureserviceCompanyService
             result = await _pureserviceCaller.GetAsync<CompanyDepartmentList>($"{DepartmentBasePath}?{queryString}");
             if (result is null)
             {
-                _logger.LogError("No result returned from API from start {Start} with limit {Limit}", currentStart, limit);
-                return departmentList;
+                throw new InvalidOperationException($"No result returned from Pureservice API from start {currentStart} with limit {limit}");
             }
             
             _logger.LogDebug("Fetched {Count} Pureservice departments starting from {Start} with limit {Limit}", result.Companydepartments.Count, currentStart, limit);
@@ -243,8 +242,7 @@ public class PureserviceCompanyService : IPureserviceCompanyService
             result = await _pureserviceCaller.GetAsync<CompanyLocationList>($"{LocationBasePath}?{queryString}");
             if (result is null)
             {
-                _logger.LogError("No result returned from API from start {Start} with limit {Limit}", currentStart, limit);
-                return locationList;
+                throw new InvalidOperationException($"No result returned from Pureservice API from start {currentStart} with limit {limit}");
             }
             
             _logger.LogDebug("Fetched {Count} Pureservice locations starting from {Start} with limit {Limit}", result.Companylocations.Count, currentStart, limit);

--- a/pureservice-dotnet/Services/PureserviceUserService.cs
+++ b/pureservice-dotnet/Services/PureserviceUserService.cs
@@ -117,8 +117,7 @@ public class PureserviceUserService : IPureserviceUserService
             result = await _pureserviceCaller.GetAsync<UserList>($"{BasePath}?{queryString}");
             if (result is null)
             {
-                _logger.LogError("No result returned from API from start {Start} with limit {Limit}", currentStart, limit);
-                return userList;
+                throw new InvalidOperationException($"No result returned from Pureservice API from start {currentStart} with limit {limit}");
             }
             
             _logger.LogDebug("Fetched {Count} users starting from {Start} with limit {Limit}", result.Users.Count, currentStart, limit);


### PR DESCRIPTION
Halt execution if crucial GET calls fails. This to prevent duplicates, or more exceptions because a record with the same value already exists

Fixes #19 